### PR TITLE
(AP-26) Move rendering error handling to ErrorBoundary component

### DIFF
--- a/src/lib/components/App/__tests__/__snapshots__/app.spec.js.snap
+++ b/src/lib/components/App/__tests__/__snapshots__/app.spec.js.snap
@@ -28,34 +28,6 @@ exports[`renders with configError 1`] = `
 </div>
 `;
 
-exports[`renders with renderErrors 1`] = `
-<div>
-  Title
-  <Main
-    isMasked={true}
-  />
-  <button />
-  <ToastContainer />
-  <div
-    className="loading-overlay"
-  >
-    <div
-      className="bounce-loader"
-    >
-      <div
-        className="bounce1"
-      />
-      <div
-        className="bounce2"
-      />
-      <div
-        className="bounce3"
-      />
-    </div>
-  </div>
-</div>
-`;
-
 exports[`renders with unhandledErrors 1`] = `
 <div>
   Title

--- a/src/lib/components/App/__tests__/app.spec.js
+++ b/src/lib/components/App/__tests__/app.spec.js
@@ -290,29 +290,6 @@ test('displays open nav', () => {
     getAndConfirmProps(openNav, MobileMenu);
 });
 
-test('renders with renderErrors', () => {
-    const appProps = {
-        app: {
-            drawer: '',
-            overlay: false,
-            hasBeenOffline: true,
-            isOnline: false
-        },
-        closeDrawer: jest.fn(),
-        markErrorHandled: jest.fn(),
-        unhandledErrors: [],
-        renderError: new Error('A render error!')
-    };
-
-    const root = createTestInstance(
-        <Router>
-            <App {...appProps} />
-        </Router>
-    );
-
-    expect(root.toJSON()).toMatchSnapshot();
-});
-
 test('renders with unhandledErrors', () => {
     const appProps = {
         app: {
@@ -384,35 +361,6 @@ test('adds no toasts when no errors are present', () => {
     );
 
     expect(mockAddToast).not.toHaveBeenCalled();
-});
-
-test('adds toasts for render errors', () => {
-    const appProps = {
-        app: {
-            drawer: '',
-            overlay: false,
-            hasBeenOffline: true,
-            isOnline: false
-        },
-        closeDrawer: jest.fn(),
-        markErrorHandled: jest.fn(),
-        unhandledErrors: [],
-        renderError: new Error('A render error!')
-    };
-
-    createTestInstance(
-        <Router>
-            <App {...appProps} />
-        </Router>
-    );
-
-    expect(mockAddToast).toHaveBeenCalledWith({
-        icon: expect.any(Object),
-        message: expect.any(String),
-        onDismiss: expect.any(Function),
-        timeout: expect.any(Number),
-        type: 'error'
-    });
 });
 
 test('adds toasts for unhandled errors', () => {

--- a/src/lib/components/App/app.tsx
+++ b/src/lib/components/App/app.tsx
@@ -41,14 +41,15 @@ const ERROR_MESSAGE = 'Sorry! An unexpected error occurred.';
 
 interface IAppProps {
     markErrorHandled: () => void;
-    renderError: {
-        stack: string;
-    };
-    unhandledErrors: string[];
+    unhandledErrors: {
+        error: Error;
+        id: string;
+        loc: string;
+    }[];
 }
 
 const App = (props: IAppProps): JSX.Element => {
-    const { markErrorHandled, renderError, unhandledErrors } = props;
+    const { markErrorHandled, unhandledErrors } = props;
     const [, { addToast }] = useToasts();
 
     const handleIsOffline = useCallback(() => {
@@ -113,7 +114,6 @@ const App = (props: IAppProps): JSX.Element => {
         handleIsOnline,
         handleHTMLUpdate,
         markErrorHandled,
-        renderError,
         unhandledErrors
     });
 
@@ -158,7 +158,7 @@ const App = (props: IAppProps): JSX.Element => {
         return () => removeHistoryListener();
     }, [addHistoryListener]);
 
-    if (renderError || configError || userDetailsError) {
+    if (configError || userDetailsError) {
         return (
             <HeadProvider>
                 <Suspense fallback={<LoadingOverlay />}>

--- a/src/lib/components/App/useErrorBoundary.tsx
+++ b/src/lib/components/App/useErrorBoundary.tsx
@@ -21,16 +21,41 @@ export const useErrorBoundary = (WrappedComponent: ReactNode) =>
                     return { renderError };
                 }
 
+                componentDidUpdate() {
+                    if (this.state.renderError) {
+                        this.recoverFromError();
+                    }
+                }
+
+                recoverFromError() {
+                    if (process.env.NODE_ENV === 'development') {
+                        console.log(
+                            'Default window.location.reload() error handler not running in developer mode.'
+                        );
+                        return;
+                    }
+
+                    window.location.reload();
+                }
+
                 render(): ReactNode {
                     const { props, state } = this;
                     const { renderError } = state;
 
+                    /**
+                     * Moved render error handling up here to prevent
+                     * invoking the same errors all over again when
+                     * rendering the very same tree.
+                     *
+                     * Put your desired view for these type of errors
+                     */
+                    if (renderError) {
+                        return <p>Render error has occurred</p>;
+                    }
+
                     return (
                         // @ts-expect-error
-                        <WrappedComponent
-                            {...props}
-                            renderError={renderError}
-                        />
+                        <WrappedComponent {...props} />
                     );
                 }
             },


### PR DESCRIPTION
Move rendering error handling up to ErrorBoundary component. 

Currently, if there has been a rendering error - the ErrorBoundary component catches the error and renders the very same wrapped component (App) with additional render error prop passed. The App component handles both redux and render errors further in `useApp` hook. This behaviour is not good, since the very same errors that were catched by the ErrorBoundary component might occur when rendering the very same component again. This causes an infinite error loop.

To prevent this behaviour, render error handling has been moved up in the tree to the ErrorBoundary component, which should render specific view (or just, handle it differently) when error has been catched. It will also handle the recovery callback, which is a page reload in current case. Changes would also separate completely different error type handling in the same place (decreasing the amount of <App/> responsibilities and complexity).